### PR TITLE
feat: Implement dashboard ranking system

### DIFF
--- a/src/main/java/com/project/deokhugam/DeokhugamTeam10Application.java
+++ b/src/main/java/com/project/deokhugam/DeokhugamTeam10Application.java
@@ -2,8 +2,10 @@ package com.project.deokhugam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DeokhugamTeam10Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/project/deokhugam/dashboard/batch/DashboardBatchScheduler.java
+++ b/src/main/java/com/project/deokhugam/dashboard/batch/DashboardBatchScheduler.java
@@ -1,0 +1,30 @@
+package com.project.deokhugam.dashboard.batch;
+
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.deokhugam.dashboard.service.DashboardService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DashboardBatchScheduler {
+
+	private final DashboardService dashboardService;
+
+	// 매일 자정 (00:00)에 실행
+	@Scheduled(cron = "0 0 0 * * *")
+	@Transactional
+	public void runDailyBatch() {
+		LocalDateTime start = LocalDateTime.now().minusDays(1);
+		LocalDateTime end = LocalDateTime.now();
+
+		dashboardService.calculateDailyBookRanking(start, end);
+		dashboardService.calculateDailyReviewRanking(start, end);
+		dashboardService.calculateDailyPowerUserRanking(start, end);
+	}
+}

--- a/src/main/java/com/project/deokhugam/dashboard/batch/ManualBatchRunner.java
+++ b/src/main/java/com/project/deokhugam/dashboard/batch/ManualBatchRunner.java
@@ -1,0 +1,27 @@
+package com.project.deokhugam.dashboard.batch;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.deokhugam.dashboard.service.DashboardBatchService;
+
+import lombok.RequiredArgsConstructor;
+
+// 00시에 자동 업데이트 설정으로 테스트 하려고 만든 Batch 클래스
+@Component
+@RequiredArgsConstructor
+public class ManualBatchRunner implements CommandLineRunner {
+
+	private final DashboardBatchService dashboardBatchService;
+
+	@Override
+	@Transactional
+	public void run(String... args) {
+		System.out.println("🔄 Manually triggering ALL dashboard period batch updates...");
+
+		dashboardBatchService.updateAllDashboardPeriods(); // ✅ 전체 기간 실행
+
+		System.out.println("✅ All period dashboard batch update completed.");
+	}
+}

--- a/src/main/java/com/project/deokhugam/dashboard/controller/RankingController.java
+++ b/src/main/java/com/project/deokhugam/dashboard/controller/RankingController.java
@@ -1,0 +1,64 @@
+package com.project.deokhugam.dashboard.controller;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.deokhugam.dashboard.dto.CursorPageResponse;
+import com.project.deokhugam.dashboard.dto.DashboardPeriod;
+import com.project.deokhugam.dashboard.dto.PopularBookDto;
+import com.project.deokhugam.dashboard.dto.PopularReviewDto;
+import com.project.deokhugam.dashboard.dto.PowerUserDto;
+import com.project.deokhugam.dashboard.service.DashboardService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class RankingController {
+
+	private final DashboardService dashboardService;
+
+	// 리뷰 랭킹
+	@GetMapping("/reviews/popular")
+	public CursorPageResponse<PopularReviewDto> getPopularReviews(
+		@RequestParam DashboardPeriod period,
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime after,
+		@RequestParam(defaultValue = "ASC") String direction,
+		@PageableDefault(size = 10, sort = "rank") Pageable pageable
+	) {
+		return dashboardService.getPopularReviews(period.name(), cursor, after, direction, pageable);
+	}
+
+	// 책 랭킹
+	@GetMapping("/books/popular")
+	public CursorPageResponse<PopularBookDto> getPopularBooks(
+		@RequestParam DashboardPeriod period,
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime after,
+		@RequestParam(defaultValue = "ASC") String direction,
+		@PageableDefault(size = 10, sort = "rank") Pageable pageable
+	) {
+		return dashboardService.getPopularBooks(period.name(), cursor, after, direction, pageable);
+	}
+
+	// 유저 랭킹
+	@GetMapping("/users/power")
+	public CursorPageResponse<PowerUserDto> getPowerUsers(
+		@RequestParam DashboardPeriod period,
+		@RequestParam(required = false) Double cursor,
+		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime after,
+		@RequestParam(defaultValue = "ASC") String direction,
+		@PageableDefault(size = 10, sort = "rank") Pageable pageable
+	) {
+		return dashboardService.getPowerUsers(period.name(), cursor, after, direction, pageable);
+	}
+}

--- a/src/main/java/com/project/deokhugam/dashboard/dto/CursorPageResponse.java
+++ b/src/main/java/com/project/deokhugam/dashboard/dto/CursorPageResponse.java
@@ -1,0 +1,25 @@
+package com.project.deokhugam.dashboard.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CursorPageResponse<T> {
+
+	private List<T> content;
+	private String nextCursor;
+	private LocalDateTime nextAfter;
+	private int size;
+	private long totalElements;
+	private boolean hasNext;
+}

--- a/src/main/java/com/project/deokhugam/dashboard/dto/DashboardPeriod.java
+++ b/src/main/java/com/project/deokhugam/dashboard/dto/DashboardPeriod.java
@@ -1,0 +1,5 @@
+package com.project.deokhugam.dashboard.dto;
+
+public enum DashboardPeriod {
+	DAILY, WEEKLY, MONTHLY, ALL_TIME
+}

--- a/src/main/java/com/project/deokhugam/dashboard/dto/DashboardType.java
+++ b/src/main/java/com/project/deokhugam/dashboard/dto/DashboardType.java
@@ -1,0 +1,5 @@
+package com.project.deokhugam.dashboard.dto;
+
+public enum DashboardType {
+	BOOK, REVIEW, USER
+}

--- a/src/main/java/com/project/deokhugam/dashboard/dto/PopularBookDto.java
+++ b/src/main/java/com/project/deokhugam/dashboard/dto/PopularBookDto.java
@@ -1,0 +1,29 @@
+package com.project.deokhugam.dashboard.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PopularBookDto {
+
+	private String id;
+	private String bookId;
+	private String title;
+	private String author;
+	private String thumbnailUrl;
+	private String period;
+	private Long rank;
+	private Double score;
+	private Long reviewCount;
+	private Double rating;
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/project/deokhugam/dashboard/dto/PopularReviewDto.java
+++ b/src/main/java/com/project/deokhugam/dashboard/dto/PopularReviewDto.java
@@ -1,0 +1,33 @@
+package com.project.deokhugam.dashboard.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PopularReviewDto {
+
+	private String id;
+	private String reviewId;
+	private String bookId;
+	private String bookTitle;
+	private String bookThumbnailUrl;
+	private String userId;
+	private String userNickname;
+	private String reviewContent;
+	private Double reviewRating;
+	private String period;
+	private LocalDateTime createdAt;
+	private Long rank;
+	private Double score;
+	private Long likeCount;
+	private Long commentCount;
+}

--- a/src/main/java/com/project/deokhugam/dashboard/dto/PowerUserDto.java
+++ b/src/main/java/com/project/deokhugam/dashboard/dto/PowerUserDto.java
@@ -1,0 +1,27 @@
+package com.project.deokhugam.dashboard.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PowerUserDto {
+
+	private String userId;
+	private String nickname;
+	private String period;
+	private LocalDateTime createdAt;
+	private Long rank;
+	private Double score;
+	private Double reviewScoreSum;
+	private Long likeCount;
+	private Long commentCount;
+}

--- a/src/main/java/com/project/deokhugam/dashboard/entity/Dashboard.java
+++ b/src/main/java/com/project/deokhugam/dashboard/entity/Dashboard.java
@@ -42,15 +42,15 @@ public class Dashboard {
 	private String period;
 
 	@Column(nullable = false)
-	private String targetId;
+	private UUID targetId;
 
-	@Column(name = "book_id", insertable = false, updatable = false)
+	@Column(name = "book_id")
 	private UUID bookId;
 
-	@Column(name = "user_id", insertable = false, updatable = false)
+	@Column(name = "user_id")
 	private UUID userId;
 
-	@Column(name = "review_id", insertable = false, updatable = false)
+	@Column(name = "review_id")
 	private UUID reviewId;
 
 	@Column(nullable = false)

--- a/src/main/java/com/project/deokhugam/dashboard/repository/DashboardRepository.java
+++ b/src/main/java/com/project/deokhugam/dashboard/repository/DashboardRepository.java
@@ -1,0 +1,61 @@
+package com.project.deokhugam.dashboard.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.project.deokhugam.dashboard.entity.Dashboard;
+
+@Repository
+public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
+
+	@Modifying
+	@Query("DELETE FROM Dashboard d WHERE d.type = :type AND d.period = :period")
+	void deleteByTypeAndPeriod(@Param("type") String type, @Param("period") String period);
+
+	@Query("SELECT d FROM Dashboard d WHERE d.type = :type AND d.period = :period ORDER BY d.rank ASC")
+	List<Dashboard> findRankingFirstPage(@Param("type") String type, @Param("period") String period,
+		org.springframework.data.domain.Pageable pageable);
+
+	@Query("""
+		SELECT d FROM Dashboard d
+		WHERE d.type = :type AND d.period = :period
+		AND (
+		    (:direction = 'ASC' AND d.rank > :cursor AND d.createdAt > :after) OR
+		    (:direction = 'DESC' AND d.rank < :cursor AND d.createdAt < :after)
+		)
+		ORDER BY d.rank ASC
+		""")
+	List<Dashboard> findRankingWithCursor(
+		@Param("type") String type,
+		@Param("period") String period,
+		@Param("direction") String direction,
+		@Param("cursor") Long cursor,
+		@Param("after") java.time.LocalDateTime after,
+		org.springframework.data.domain.Pageable pageable
+	);
+
+	@Query("""
+		SELECT d FROM Dashboard d
+		WHERE d.type = :type AND d.period = :period
+		AND (
+		    (:direction = 'ASC' AND d.score > :cursor AND d.createdAt > :after) OR
+		    (:direction = 'DESC' AND d.score < :cursor AND d.createdAt < :after)
+		)
+		ORDER BY d.score ASC
+		""")
+	List<Dashboard> findRankingWithCursor(
+		@Param("type") String type,
+		@Param("period") String period,
+		@Param("direction") String direction,
+		@Param("cursor") Double cursor,
+		@Param("after") java.time.LocalDateTime after,
+		org.springframework.data.domain.Pageable pageable
+	);
+
+	long countByTypeAndPeriod(String type, String period);
+}

--- a/src/main/java/com/project/deokhugam/dashboard/service/DashboardBatchService.java
+++ b/src/main/java/com/project/deokhugam/dashboard/service/DashboardBatchService.java
@@ -1,0 +1,193 @@
+package com.project.deokhugam.dashboard.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.deokhugam.dashboard.entity.Dashboard;
+import com.project.deokhugam.dashboard.repository.DashboardRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardBatchService {
+
+	private final DashboardRepository dashboardRepository;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Scheduled(cron = "0 0 0 * * *")
+	@Transactional
+	public void updateAllDashboardPeriods() {
+		LocalDateTime now = LocalDateTime.now();
+
+		updateRankingForPeriod("DAILY", now.minusDays(1), now);
+		updateRankingForPeriod("WEEKLY", now.minusWeeks(1), now);
+		updateRankingForPeriod("MONTHLY", now.minusMonths(1), now);
+		updateRankingForPeriod("ALL_TIME", null, now);
+	}
+
+	private void updateRankingForPeriod(String period, LocalDateTime start, LocalDateTime end) {
+		dashboardRepository.deleteByTypeAndPeriod("BOOK", period);
+		dashboardRepository.deleteByTypeAndPeriod("REVIEW", period);
+		dashboardRepository.deleteByTypeAndPeriod("USER", period);
+
+		updateBookRanking(start, end, period);
+		updateReviewRanking(start, end, period);
+		updatePowerUserRanking(start, end, period);
+	}
+
+	private void updateBookRanking(LocalDateTime start, LocalDateTime end, String period) {
+		List<Object[]> results = createNativeQueryWithOptionalDates(
+			"SELECT r.book_id, COUNT(r.review_id), AVG(r.review_rating) " +
+				"FROM review r " +
+				(getWhereClause(start)) +
+				" GROUP BY r.book_id",
+			start, end
+		);
+
+		results.sort((a, b) -> {
+			double scoreA = ((Number)a[1]).doubleValue() * 0.4 + ((Number)a[2]).doubleValue() * 0.6;
+			double scoreB = ((Number)b[1]).doubleValue() * 0.4 + ((Number)b[2]).doubleValue() * 0.6;
+			return Double.compare(scoreB, scoreA);
+		});
+
+		double prevScore = -1;
+		int rank = 0, sameRankCount = 1;
+
+		for (Object[] row : results) {
+			UUID bookId = (UUID)row[0];
+			long reviewCount = ((Number)row[1]).longValue();
+			double rating = ((Number)row[2]).doubleValue();
+			double score = reviewCount * 0.4 + rating * 0.6;
+
+			if (score != prevScore) {
+				rank += sameRankCount;
+				sameRankCount = 1;
+			} else {
+				sameRankCount++;
+			}
+			prevScore = score;
+
+			dashboardRepository.save(Dashboard.builder()
+				.type("BOOK").period(period)
+				.targetId(bookId).bookId(bookId)
+				.score(score).rank((long)rank)
+				.reviewCount(reviewCount).reviewRating(rating)
+				.createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+				.build());
+		}
+	}
+
+	private void updateReviewRanking(LocalDateTime start, LocalDateTime end, String period) {
+		List<Object[]> results = createNativeQueryWithOptionalDates(
+			"SELECT r.review_id, r.book_id, r.user_id, r.like_count, r.comment_count, r.review_rating " +
+				"FROM review r " +
+				getWhereClause(start),
+			start, end
+		);
+
+		results.sort((a, b) -> {
+			double scoreA = ((Number)a[3]).doubleValue() * 0.3 + ((Number)a[4]).doubleValue() * 0.7;
+			double scoreB = ((Number)b[3]).doubleValue() * 0.3 + ((Number)b[4]).doubleValue() * 0.7;
+			return Double.compare(scoreB, scoreA);
+		});
+
+		double prevScore = -1;
+		int rank = 0, sameRankCount = 1;
+
+		for (Object[] row : results) {
+			UUID reviewId = (UUID)row[0];
+			UUID bookId = (UUID)row[1];
+			UUID userId = (UUID)row[2];
+			long likeCount = ((Number)row[3]).longValue();
+			long commentCount = ((Number)row[4]).longValue();
+			double rating = ((Number)row[5]).doubleValue();
+			double score = likeCount * 0.3 + commentCount * 0.7;
+
+			if (score != prevScore) {
+				rank += sameRankCount;
+				sameRankCount = 1;
+			} else {
+				sameRankCount++;
+			}
+			prevScore = score;
+
+			dashboardRepository.save(Dashboard.builder()
+				.type("REVIEW").period(period)
+				.targetId(reviewId).reviewId(reviewId).bookId(bookId).userId(userId)
+				.score(score).rank((long)rank)
+				.likeCount(likeCount).commentCount(commentCount).reviewRating(rating)
+				.createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+				.build());
+		}
+	}
+
+	private void updatePowerUserRanking(LocalDateTime start, LocalDateTime end, String period) {
+		List<Object[]> results = createNativeQueryWithOptionalDates(
+			"SELECT r.user_id, SUM(d.score), SUM(d.like_count), SUM(d.comment_count) " +
+				"FROM dashboard d JOIN review r ON d.review_id = r.review_id " +
+				"WHERE d.type = 'REVIEW' " +
+				(start != null ? "AND d.created_at BETWEEN :start AND :end " : "") +
+				"GROUP BY r.user_id",
+			start, end
+		);
+
+		results.sort((a, b) -> {
+			double scoreA = ((Number)a[1]).doubleValue() * 0.5 + ((Number)a[2]).doubleValue() * 0.2
+				+ ((Number)a[3]).doubleValue() * 0.3;
+			double scoreB = ((Number)b[1]).doubleValue() * 0.5 + ((Number)b[2]).doubleValue() * 0.2
+				+ ((Number)b[3]).doubleValue() * 0.3;
+			return Double.compare(scoreB, scoreA);
+		});
+
+		double prevScore = -1;
+		int rank = 0, sameRankCount = 1;
+
+		for (Object[] row : results) {
+			UUID userId = (UUID)row[0];
+			double reviewScoreSum = ((Number)row[1]).doubleValue();
+			long likeCount = ((Number)row[2]).longValue();
+			long commentCount = ((Number)row[3]).longValue();
+			double score = reviewScoreSum * 0.5 + likeCount * 0.2 + commentCount * 0.3;
+
+			if (score != prevScore) {
+				rank += sameRankCount;
+				sameRankCount = 1;
+			} else {
+				sameRankCount++;
+			}
+			prevScore = score;
+
+			dashboardRepository.save(Dashboard.builder()
+				.type("USER").period(period)
+				.targetId(userId).userId(userId)
+				.score(score).rank((long)rank)
+				.reviewScoreSum(reviewScoreSum).likeCount(likeCount).commentCount(commentCount)
+				.createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+				.build());
+		}
+	}
+
+	private List<Object[]> createNativeQueryWithOptionalDates(String baseQuery, LocalDateTime start,
+		LocalDateTime end) {
+		var query = entityManager.createNativeQuery(baseQuery);
+		if (start != null && end != null) {
+			query.setParameter("start", start);
+			query.setParameter("end", end);
+		}
+		return query.getResultList();
+	}
+
+	private String getWhereClause(LocalDateTime start) {
+		return start != null ? "WHERE r.created_at BETWEEN :start AND :end" : "";
+	}
+}

--- a/src/main/java/com/project/deokhugam/dashboard/service/DashboardService.java
+++ b/src/main/java/com/project/deokhugam/dashboard/service/DashboardService.java
@@ -1,0 +1,28 @@
+package com.project.deokhugam.dashboard.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Pageable;
+
+import com.project.deokhugam.dashboard.dto.CursorPageResponse;
+import com.project.deokhugam.dashboard.dto.PopularBookDto;
+import com.project.deokhugam.dashboard.dto.PopularReviewDto;
+import com.project.deokhugam.dashboard.dto.PowerUserDto;
+
+public interface DashboardService {
+	CursorPageResponse<PopularReviewDto> getPopularReviews(String period, Long cursor, LocalDateTime after,
+		String direction, Pageable pageable);
+
+	CursorPageResponse<PopularBookDto> getPopularBooks(String period, Long cursor, LocalDateTime after,
+		String direction, Pageable pageable);
+
+	CursorPageResponse<PowerUserDto> getPowerUsers(
+		String period, Double cursor, LocalDateTime after,
+		String direction, Pageable pageable);
+
+	void calculateDailyBookRanking(LocalDateTime start, LocalDateTime end);
+
+	void calculateDailyReviewRanking(LocalDateTime start, LocalDateTime end);
+
+	void calculateDailyPowerUserRanking(LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/project/deokhugam/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/project/deokhugam/dashboard/service/DashboardServiceImpl.java
@@ -1,0 +1,289 @@
+package com.project.deokhugam.dashboard.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.project.deokhugam.dashboard.dto.CursorPageResponse;
+import com.project.deokhugam.dashboard.dto.PopularBookDto;
+import com.project.deokhugam.dashboard.dto.PopularReviewDto;
+import com.project.deokhugam.dashboard.dto.PowerUserDto;
+import com.project.deokhugam.dashboard.entity.Dashboard;
+import com.project.deokhugam.dashboard.repository.DashboardRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardServiceImpl implements DashboardService {
+
+	private final DashboardRepository dashboardRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Override
+	public CursorPageResponse<PopularReviewDto> getPopularReviews(
+		String period, Long cursor, LocalDateTime after,
+		String direction, Pageable pageable) {
+		return getCursorPageResponse("REVIEW", period, cursor, after, direction, pageable, this::toPopularReviewDto);
+	}
+
+	@Override
+	public CursorPageResponse<PopularBookDto> getPopularBooks(
+		String period, Long cursor, LocalDateTime after,
+		String direction, Pageable pageable) {
+		return getCursorPageResponse("BOOK", period, cursor, after, direction, pageable, this::toPopularBookDto);
+	}
+
+	@Override
+	public CursorPageResponse<PowerUserDto> getPowerUsers(
+		String period, Double cursor, LocalDateTime after,
+		String direction, Pageable pageable) {
+		return getCursorPageResponse("USER", period, cursor, after, direction, pageable, this::toPowerUserDto);
+	}
+
+	private <T, C extends Comparable<C>> CursorPageResponse<T> getCursorPageResponse(
+		String type, String period, C cursor, LocalDateTime after,
+		String direction, Pageable pageable, Function<Dashboard, T> mapper) {
+
+		Pageable sorted = PageRequest.of(0, pageable.getPageSize(), getSort(type, direction));
+		List<Dashboard> result;
+
+		if (cursor != null && after == null) {
+			return CursorPageResponse.<T>builder()
+				.content(List.of())
+				.nextCursor(null)
+				.nextAfter(null)
+				.size(pageable.getPageSize())
+				.totalElements(0)
+				.hasNext(false)
+				.build();
+		}
+
+		if (cursor == null || after == null) {
+			result = dashboardRepository.findRankingFirstPage(type, period, sorted);
+		} else {
+			if ("USER".equals(type)) {
+				result = dashboardRepository.findRankingWithCursor(type, period, direction, (Double)cursor, after,
+					sorted);
+			} else {
+				result = dashboardRepository.findRankingWithCursor(type, period, direction, (Long)cursor, after,
+					sorted);
+			}
+		}
+
+		List<T> content = result.stream().map(mapper).toList();
+		boolean hasNext = result.size() == pageable.getPageSize();
+		String nextCursor = hasNext
+			? ("USER".equals(type)
+			? String.valueOf(result.get(result.size() - 1).getScore())
+			: String.valueOf(result.get(result.size() - 1).getRank()))
+			: null;
+
+		return CursorPageResponse.<T>builder()
+			.content(content)
+			.nextCursor(nextCursor)
+			.nextAfter(hasNext ? result.get(result.size() - 1).getCreatedAt() : null)
+			.size(pageable.getPageSize())
+			.totalElements(dashboardRepository.countByTypeAndPeriod(type, period))
+			.hasNext(hasNext)
+			.build();
+	}
+
+	private Sort getSort(String type, String direction) {
+		if ("USER".equals(type)) {
+			return direction.equalsIgnoreCase("ASC")
+				? Sort.by(Sort.Order.asc("score"), Sort.Order.asc("createdAt"))
+				: Sort.by(Sort.Order.desc("score"), Sort.Order.desc("createdAt"));
+		}
+		return direction.equalsIgnoreCase("ASC")
+			? Sort.by(Sort.Order.asc("rank"), Sort.Order.asc("createdAt"))
+			: Sort.by(Sort.Order.desc("rank"), Sort.Order.desc("createdAt"));
+	}
+
+	@Override
+	@Transactional
+	public void calculateDailyBookRanking(LocalDateTime start, LocalDateTime end) {
+		dashboardRepository.deleteByTypeAndPeriod("BOOK", "DAILY");
+
+		List<Object[]> results = em.createNativeQuery(
+				"SELECT r.book_id, COUNT(r.review_id), AVG(r.review_rating), MIN(r.created_at) " +
+					"FROM review r WHERE r.created_at BETWEEN :start AND :end GROUP BY r.book_id")
+			.setParameter("start", start)
+			.setParameter("end", end)
+			.getResultList();
+
+		results.sort((a, b) -> {
+			double scoreA = ((Number)a[1]).doubleValue() * 0.4 + ((Number)a[2]).doubleValue() * 0.6;
+			double scoreB = ((Number)b[1]).doubleValue() * 0.4 + ((Number)b[2]).doubleValue() * 0.6;
+			int scoreCompare = Double.compare(scoreB, scoreA);
+			if (scoreCompare != 0)
+				return scoreCompare;
+			return ((LocalDateTime)a[3]).compareTo((LocalDateTime)b[3]);
+		});
+
+		int rank = 1;
+		for (Object[] row : results) {
+			UUID bookId = (UUID)row[0];
+			long reviewCount = ((Number)row[1]).longValue();
+			double avgRating = ((Number)row[2]).doubleValue();
+			double score = reviewCount * 0.4 + avgRating * 0.6;
+
+			dashboardRepository.save(Dashboard.builder()
+				.type("BOOK").period("DAILY")
+				.targetId(bookId).bookId(bookId)
+				.score(score).rank((long)rank++)
+				.reviewCount(reviewCount).reviewRating(avgRating)
+				.createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+				.build());
+		}
+	}
+
+	@Override
+	@Transactional
+	public void calculateDailyReviewRanking(LocalDateTime start, LocalDateTime end) {
+		dashboardRepository.deleteByTypeAndPeriod("REVIEW", "DAILY");
+
+		List<Object[]> results = em.createNativeQuery(
+				"SELECT r.review_id, r.book_id, r.user_id, r.like_count, r.comment_count, r.review_rating, r.created_at " +
+					"FROM review r WHERE r.created_at BETWEEN :start AND :end")
+			.setParameter("start", start)
+			.setParameter("end", end)
+			.getResultList();
+
+		results.sort((a, b) -> {
+			double scoreA = ((Number)a[3]).doubleValue() * 0.3 + ((Number)a[4]).doubleValue() * 0.7;
+			double scoreB = ((Number)b[3]).doubleValue() * 0.3 + ((Number)b[4]).doubleValue() * 0.7;
+			int scoreCompare = Double.compare(scoreB, scoreA);
+			if (scoreCompare != 0)
+				return scoreCompare;
+			return ((LocalDateTime)a[6]).compareTo((LocalDateTime)b[6]);
+		});
+
+		int rank = 1;
+		for (Object[] row : results) {
+			UUID reviewId = (UUID)row[0];
+			UUID bookId = (UUID)row[1];
+			UUID userId = (UUID)row[2];
+			long likeCount = row[3] != null ? ((Number)row[3]).longValue() : 0L;
+			long commentCount = row[4] != null ? ((Number)row[4]).longValue() : 0L;
+			double rating = row[5] != null ? ((Number)row[5]).doubleValue() : 0.0;
+			double score = likeCount * 0.3 + commentCount * 0.7;
+
+			dashboardRepository.save(Dashboard.builder()
+				.type("REVIEW").period("DAILY")
+				.targetId(reviewId).reviewId(reviewId).bookId(bookId).userId(userId)
+				.score(score).rank((long)rank++)
+				.likeCount(likeCount).commentCount(commentCount).reviewRating(rating)
+				.createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+				.build());
+		}
+	}
+
+	@Override
+	@Transactional
+	public void calculateDailyPowerUserRanking(LocalDateTime start, LocalDateTime end) {
+		dashboardRepository.deleteByTypeAndPeriod("USER", "DAILY");
+
+		List<Object[]> results = em.createNativeQuery(
+				"SELECT r.user_id, SUM(d.score), SUM(d.like_count), SUM(d.comment_count), MIN(d.created_at) " +
+					"FROM dashboard d JOIN review r ON d.review_id = r.review_id " +
+					"WHERE d.type = 'REVIEW' AND d.created_at BETWEEN :start AND :end " +
+					"GROUP BY r.user_id")
+			.setParameter("start", start)
+			.setParameter("end", end)
+			.getResultList();
+
+		results.sort((a, b) -> {
+			double scoreA = ((Number)a[1]).doubleValue() * 0.5 + ((Number)a[2]).doubleValue() * 0.2
+				+ ((Number)a[3]).doubleValue() * 0.3;
+			double scoreB = ((Number)b[1]).doubleValue() * 0.5 + ((Number)b[2]).doubleValue() * 0.2
+				+ ((Number)b[3]).doubleValue() * 0.3;
+			int scoreCompare = Double.compare(scoreB, scoreA);
+			if (scoreCompare != 0)
+				return scoreCompare;
+			return ((LocalDateTime)a[4]).compareTo((LocalDateTime)b[4]);
+		});
+
+		int rank = 1;
+		for (Object[] row : results) {
+			UUID userId = (UUID)row[0];
+			double reviewScoreSum = ((Number)row[1]).doubleValue();
+			long likeCount = ((Number)row[2]).longValue();
+			long commentCount = ((Number)row[3]).longValue();
+			double score = reviewScoreSum * 0.5 + likeCount * 0.2 + commentCount * 0.3;
+
+			dashboardRepository.save(Dashboard.builder()
+				.type("USER").period("DAILY")
+				.targetId(userId).userId(userId)
+				.score(score).rank((long)rank++)
+				.reviewScoreSum(reviewScoreSum).likeCount(likeCount).commentCount(commentCount)
+				.createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+				.build());
+		}
+	}
+
+	private PopularReviewDto toPopularReviewDto(Dashboard d) {
+		return PopularReviewDto.builder()
+			.id(toStringSafe(d.getId()))
+			.reviewId(toStringSafe(d.getReviewId()))
+			.bookId(toStringSafe(d.getBookId()))
+			.userId(toStringSafe(d.getUserId()))
+			.period(d.getPeriod())
+			.createdAt(d.getCreatedAt())
+			.rank(d.getRank())
+			.score(d.getScore())
+			.reviewRating(d.getReviewRating())
+			.likeCount(d.getLikeCount())
+			.commentCount(d.getCommentCount())
+			.bookTitle(d.getBook() != null ? d.getBook().getTitle() : null)
+			.bookThumbnailUrl(d.getBook() != null ? d.getBook().getThumbnailUrl() : null)
+			.userNickname(d.getUser() != null ? d.getUser().getNickname() : null)
+			.reviewContent(d.getReview() != null ? d.getReview().getReviewContent() : null)
+			.build();
+	}
+
+	private PopularBookDto toPopularBookDto(Dashboard d) {
+		return PopularBookDto.builder()
+			.id(toStringSafe(d.getId()))
+			.bookId(toStringSafe(d.getBookId()))
+			.title(d.getBook() != null ? d.getBook().getTitle() : null)
+			.author(d.getBook() != null ? d.getBook().getAuthor() : null)
+			.thumbnailUrl(d.getBook() != null ? d.getBook().getThumbnailUrl() : null)
+			.period(d.getPeriod())
+			.createdAt(d.getCreatedAt())
+			.rank(d.getRank())
+			.score(d.getScore())
+			.reviewCount(d.getReviewCount())
+			.rating(d.getReviewRating())
+			.build();
+	}
+
+	private PowerUserDto toPowerUserDto(Dashboard d) {
+		return PowerUserDto.builder()
+			.userId(toStringSafe(d.getUserId()))
+			.nickname(d.getUser() != null ? d.getUser().getNickname() : null)
+			.period(d.getPeriod())
+			.createdAt(d.getCreatedAt())
+			.rank(d.getRank())
+			.score(d.getScore())
+			.reviewScoreSum(d.getReviewScoreSum())
+			.likeCount(d.getLikeCount())
+			.commentCount(d.getCommentCount())
+			.build();
+	}
+
+	private String toStringSafe(UUID id) {
+		return id != null ? id.toString() : null;
+	}
+}


### PR DESCRIPTION
- 점수가 동점일 경우 인기순위는 created_at 기준으로 빠른순으로 순위매겨짐
- 리뷰, 책, 사용자에 대한 일간 랭킹 집계 기능 구현
- @Scheduled 사용하여 매일 00:00에 랭킹 자동 업데이트
- 커서 기반 페이지네이션 API 구현 (PopularBook, PopularReview, PowerUser)
- 기간별 랭킹(DAILY, WEEKLY, MONTHLY, ALL_TIME) 저장 로직 구성 / 변경예정
- Dashboard 테이블 설계 및 관련 Repository, Service 분리
- 중복 데이터 저장 방지 로직 일부 반영
